### PR TITLE
fix: adding gh deploy step to deploy to engineering.beyondpricing.com

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -10,14 +10,13 @@ on:
 
 jobs:
   continuous-delivery:
-
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # for posts's lastmod
+          fetch-depth: 0
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -25,5 +24,15 @@ jobs:
           ruby-version: 2.7
           bundler-cache: true
 
-      - name: Deploy
+      - name: Update References
         run: bash tools/deploy.sh
+
+      - name: Deploy to GitHub Pages
+        if: success()
+        uses: crazy-max/ghaction-github-pages@v3
+        with:
+          domain: https://engineering.beyondpricing.com/
+          target_branch: gh-pages
+          build_dir: ./_site
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Recently we changed our repository from `public` to `private`.

When doing this, we lost the [github-deploy-bot](https://docs.github.com/en/pages/getting-started-with-github-pages) due its permissions:

`GitHub Pages is available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see "[GitHub’s products](https://docs.github.com/en/get-started/learning-about-github/githubs-products)."`

This is how it was with the BOT:
<img width="1284" alt="Screenshot 2023-02-20 at 09 31 18" src="https://user-images.githubusercontent.com/17742979/220109093-b3f7d71e-7748-47e0-9a74-35ab3fdc4f82.png">


These changes add a new step to our current workflow, which is called `Deploy to GitHub Pages`. 
