### PR TITLE
chore: update CVE dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,11 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
-    nokogiri (1.13.3-x86_64-linux)
+    nokogiri (1.13.10-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.10-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.10-x86_64-linux)
       racc (~> 1.4)
     nokogumbo (2.0.5)
       nokogiri (~> 1.8, >= 1.8.4)
@@ -76,7 +80,7 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.7)
-    racc (1.6.0)
+    racc (1.6.2)
     rainbow (3.0.0)
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
@@ -91,7 +95,7 @@ GEM
     thread_safe (0.3.6)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (1.2.9)
+    tzinfo (1.2.11)
       thread_safe (~> 0.1)
     tzinfo-data (1.2021.5)
       tzinfo (>= 1.0.0)
@@ -102,6 +106,7 @@ GEM
 
 PLATFORMS
   universal-darwin-21
+  universal-darwin-22
   x86_64-linux
 
 DEPENDENCIES
@@ -113,4 +118,4 @@ DEPENDENCIES
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.2.24
+   2.4.7


### PR DESCRIPTION
Update dependencies to address the following CVE warnings:

CVE-2022-31163, CVE-2022-29181, CVE-2022-24836 (details can be found here: https://github.com/1024inc/engineering-blog/security)

nokogiri: 1.13.3 -->  1.13.10
tzinfo 1.2.9 --> 1.2.11

Also:
racc: 1.6.0 --> 1.6.2 